### PR TITLE
Fix: Revision of resource type definitions

### DIFF
--- a/src/cluster/basic.yaml
+++ b/src/cluster/basic.yaml
@@ -64,7 +64,7 @@ parameters:
 
   instance_type:
     type: string
-    description: The resource type to use to create cluster instances. The type must be compatible to Lib::Instance.
+    description: The resource type to use to create cluster instances. The type must be compatible to Evoila::IaaS::Instance::Basic.
     default: Evoila::IaaS::Instance::Basic
     constraints:
       - allowed_values:

--- a/src/cluster/load_balanced.yaml
+++ b/src/cluster/load_balanced.yaml
@@ -86,12 +86,12 @@ parameters:
 
   instance_type:
     type: string
-    description: The resource type to use to create cluster instances. The type must be compatible to Lib::Instance::LoadBalanced
-    default: Lib::Instance::LoadBalanced
+    description: The resource type to use to create cluster instances. The type must be compatible to Evoila::IaaS::Instance::LoadBalanced
+    default: Evoila::IaaS::Instance::LoadBalanced
     constraints:
       - allowed_values:
-        - Lib::Instance::LoadBalanced
-        - Lib::Instance::LoadBalancedV1
+        - Evoila::IaaS::Instance::LoadBalanced
+        - Evoila::IaaS::Instance::LoadBalancedV1
         - Evoila::IaaS::Instance::LoadBalanced
 
   package_upgrade:

--- a/src/cluster/load_balanced_https.yaml
+++ b/src/cluster/load_balanced_https.yaml
@@ -86,12 +86,12 @@ parameters:
 
   instance_type:
     type: string
-    description: The resource type to use to create cluster instances. The type must be compatible to Lib::Instance::LoadBalanced
-    default: Lib::Instance::LoadBalanced
+    description: The resource type to use to create cluster instances. The type must be compatible to Evoila::IaaS::Instance::LoadBalanced
+    default: Evoila::IaaS::Instance::LoadBalanced
     constraints:
       - allowed_values:
-        - Lib::Instance::LoadBalanced
-        - Lib::Instance::LoadBalancedV1
+        - Evoila::IaaS::Instance::LoadBalanced
+        - Evoila::IaaS::Instance::LoadBalancedV1
         - Evoila::IaaS::Instance::LoadBalanced
 
   url_path:

--- a/tests/cluster/load_balanced.yaml
+++ b/tests/cluster/load_balanced.yaml
@@ -79,7 +79,7 @@ resources:
         - config: { get_resource: script2 }
 
   load_balanced_cluster1:
-    type: Evoila::IaaS::Cluster::Evoila::IaaS::Cluster::LoadBalanced
+    type: Evoila::IaaS::Cluster::LoadBalanced
     properties:
       count: 2
       name: lbc


### PR DESCRIPTION
Set correct names for resource types

Remove duplicate resource type name in loadbalanced cluster test