### PR TITLE
Feature: Support of LBaaS V1

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -5,8 +5,12 @@ resource_registry:
   "Evoila::IaaS::Instance::Basic": src/instance/basic.yaml
   "Evoila::IaaS::Instance::RandomName": src/instance/random_name.yaml
   "Evoila::IaaS::Instance::LoadBalanced": src/instance/load_balanced_v2.yaml
+  "Evoila::IaaS::Instance::LoadBalancedV1": src/instance/load_balanced_v1.yaml
+  "Evoila::IaaS::Instance::LoadBalancedV2": src/instance/load_balanced_v2.yaml
   "Evoila::IaaS::Instance::LoadBalanced::RandomName": src/instance/load_balanced_v2_random_name.yaml
   "Evoila::IaaS::LoadBalancer::TCP": src/loadbalancer/tcp_v2.yaml
+  "Evoila::IaaS::LoadBalancer::TCPV1": src/loadbalancer/tcp_v1.yaml
+  "Evoila::IaaS::LoadBalancer::TCPV2": src/loadbalancer/tcp_v2.yaml
   "Evoila::IaaS::LoadBalancer::HTTP": src/loadbalancer/http_v2.yaml
   "Evoila::IaaS::LoadBalancer::HTTPS": src/loadbalancer/https_v2.yaml
   "Evoila::IaaS::Network::Connectivity": src/network/connectivity.yaml

--- a/src/cluster/load_balanced.yaml
+++ b/src/cluster/load_balanced.yaml
@@ -92,7 +92,7 @@ parameters:
       - allowed_values:
         - Evoila::IaaS::Instance::LoadBalanced
         - Evoila::IaaS::Instance::LoadBalancedV1
-        - Evoila::IaaS::Instance::LoadBalanced
+        - Evoila::IaaS::Instance::LoadBalancedV2
 
   package_upgrade:
     type: boolean

--- a/src/instance/load_balanced_v1.yaml
+++ b/src/instance/load_balanced_v1.yaml
@@ -1,0 +1,113 @@
+heat_template_version: 2015-10-15
+description: >
+  Creates an instance of Evoila::IaaS::Instance::Basic and adds it 
+  as a member to an existing LBaaS pool.
+
+parameter_groups:
+
+parameters:
+
+  name:
+    type: string
+    description: Name of the instance
+    constraints:
+      - allowed_pattern: "[a-z][a-z0-9-]{1,}"
+
+  key:
+    type: string
+    description: SSH key to inject into the instance
+    constraints:
+      - custom_constraint: nova.keypair
+
+  image:
+    type: string
+    description: Image to deploy the instance from
+    constraints:
+      - custom_constraint: glance.image
+
+  flavor:
+    type: string
+    description: Flavor to use for the instance
+    constraints:
+      - custom_constraint: nova.flavor
+
+  subnets:
+    type: comma_delimited_list
+    description: List of subnets to connect the instance to
+
+  security_groups:
+    type: comma_delimited_list
+    description: List of security groups to attach to the instance
+
+  config:
+    type: string
+    description: Configuration to apply to the instance (has to be multipart)
+    default: None
+
+  scheduler_hints:
+    type: json
+    description: A map used for scheduling a set of instances on different hosts
+    default: {}
+
+  pool:
+    type: string
+    description: The load balancer pool
+
+  extras:
+    type: json
+    description: >
+      A map which is used in addition to the default parameters.
+
+resources:
+
+  node:
+    type: Evoila::IaaS::Instance::Basic
+    properties:
+      name: { get_param: name }
+      key: { get_param: key }
+      image: { get_param: image }
+      flavor: { get_param: flavor }
+      config: { get_param: config }
+      security_groups: { get_param: security_groups }
+      subnets: { get_param: subnets }
+      scheduler_hints: { get_param: scheduler_hints }
+      extras: { get_param: extras }
+
+  member:
+    type: OS::Neutron::PoolMember
+    properties:
+      pool_id: { get_param: pool }
+      address: { get_attr: [ node, first_address ] }
+      protocol_port: { get_param: [ extras, port ] }
+
+outputs:
+
+  id:
+    value: { get_attr: [ node, id ] }
+
+  accessIPv4:
+    value: { get_attr: [node, accessIPv4] }
+
+  accessIPv6:
+    value: { get_attr: [node, accessIPv6] }
+
+  addresses:
+    value: { get_attr: [node, addresses] }
+
+  console_urls:
+    value: { get_attr: [node, console_urls] }
+
+  first_address:
+    value: { get_attr: [node, first_address] }
+
+  instance_name:
+    value: { get_attr: [node, instance_name] }
+
+  name:
+    value: { get_attr: [node, name] }
+
+  networks:
+    value: { get_attr: [node, networks] }
+
+  show:
+    value: { get_attr: [node, show] }

--- a/src/loadbalancer/tcp_v1.yaml
+++ b/src/loadbalancer/tcp_v1.yaml
@@ -1,0 +1,71 @@
+heat_template_version: 2015-10-15 
+description: >
+  This is a load balancer for TCP services based on LBaaS V1. It
+  implements a best practice configuration.
+
+parameter_groups:
+
+parameters:
+
+  name:
+    description: Name of the load balancer
+    type: string
+    constraints:
+      - allowed_pattern: "[a-z][a-z0-9-]{1,}"
+
+  subnet:
+    description: Subnet to allocate the VIP in
+    type: string
+    constraints:
+      - custom_constraint: neutron.subnet
+
+  port:
+    type: number
+    description: Port the load balancer should listen on
+    constraints:
+      - range: { min: 1, max: 65535 }
+
+resources:
+
+  monitor:
+    type: OS::Neutron::HealthMonitor
+    properties:
+      type: TCP
+      delay: 5
+      max_retries: 3
+      timeout: 2
+
+  pool:
+    type: OS::Neutron::Pool
+    properties:
+      name:
+        list_join: ['-', [{ get_param: name }, 'pool']]
+      protocol: TCP
+      subnet_id: { get_param: subnet }
+      lb_method: ROUND_ROBIN
+      monitors:
+        - { get_resource: monitor }
+      vip:
+        name:
+          list_join: ['-', [{ get_param: name }, 'vip']]
+        protocol_port: { get_param: port }
+        session_persistence:
+          type: SOURCE_IP
+        subnet: { get_param: subnet }
+
+  loadbalancer:
+    type: OS::Neutron::LoadBalancer
+    properties:
+      pool_id: { get_resource: pool }
+      protocol_port: { get_param: port }
+
+outputs:
+
+  vip_address:
+    value: { get_attr: [ pool, vip, address ] }
+
+  vip_port_id:
+    value: { get_attr: [ pool, vip, port_id ] }
+
+  pool:
+    value: { get_resource: pool }

--- a/tests/cluster/load_balanced_v1.yaml
+++ b/tests/cluster/load_balanced_v1.yaml
@@ -1,0 +1,99 @@
+heat_template_version: 2015-10-15
+description: Load Balanced Cluster Test
+
+parameter_groups:
+
+parameters:
+
+  key:
+    type: string
+    constraints:
+      - custom_constraint: nova.keypair
+
+  image:
+    type: string
+    constraints:
+      - custom_constraint: glance.image
+
+  flavor:
+    type: string
+    constraints:
+      - custom_constraint: nova.flavor
+
+  public_network:
+    type: string
+    constraints:
+      - custom_constraint: neutron.network
+
+  dns_nameservers:
+    type: comma_delimited_list
+    description: List of DNS servers
+
+resources:
+
+  router:
+    type: OS::Neutron::Router
+    properties:
+      name: lbc-router
+      external_gateway_info:
+        network: { get_param: public_network }
+
+  networking1:
+    type: Evoila::IaaS::NetworkLayout::Simple
+    properties:
+      name: lbc
+      network_cidr: 192.168.0.0/24
+      router: { get_resource: router }
+      dns_nameservers: { get_param: dns_nameservers }
+
+  security_group:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name: lbc-secgrp
+      rules:
+        - remote_ip_prefix: 0.0.0.0/0
+
+  script1:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: ungrouped
+      config: |
+        #!/bin/bash
+        echo "Configuration 1"
+
+  config:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+        - config: { get_resource: script1 }
+
+  load_balanced_cluster1:
+    type: Evoila::IaaS::Cluster::LoadBalanced
+    properties:
+      count: 2
+      name: lbc
+      instance_type: Evoila::IaaS::Instance::LoadBalancedV1
+      key: { get_param: key }
+      image: { get_param: image }
+      flavor: { get_param: flavor }
+      security_groups:
+        - { get_resource: security_group }
+      config: { get_resource: config }
+      subnets:
+        - { get_attr: [ networking1, subnet ] }
+      extras:
+        port: 22 
+        volume_count: 0
+        volume_size: 0
+      frontend_port: 22
+
+outputs:
+
+  lb1_instances:
+    value: { get_attr: [load_balanced_cluster1, first_addresses] }
+
+  pool_vip_address_1:
+    value: { get_attr: [ load_balanced_cluster1, vip_address ] }
+
+  pool_port_id:
+    value: { get_attr: [ load_balanced_cluster1, vip_port_id ] }

--- a/tests/cluster/load_balanced_v1_env.yaml
+++ b/tests/cluster/load_balanced_v1_env.yaml
@@ -1,0 +1,2 @@
+resource_registry:
+  "Evoila::IaaS::LoadBalancer::TCP": ../../src/loadbalancer/tcp_v1.yaml 

--- a/tests/lb/lb_v1.yaml
+++ b/tests/lb/lb_v1.yaml
@@ -1,0 +1,43 @@
+heat_template_version: 2015-10-15
+description: TCP LoadBalancerV1 Test
+
+parameter_groups:
+
+parameters:
+
+  dns_nameservers:
+    type: comma_delimited_list
+    description: List of DNS servers  
+
+resources:
+
+  network:
+    type: OS::Neutron::Net
+    properties:
+      name: testnetwork
+
+  subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      name: testsubnet
+      network_id: { get_resource: network }
+      cidr: 192.168.0.0/24
+      dns_nameservers: { get_param: dns_nameservers }
+
+  loadbalancer:
+    type: Evoila::IaaS::LoadBalancer::TCPV1 
+    properties:
+      name: lb-v1
+      subnet: { get_resource: subnet }
+      port: 22
+
+outputs:
+
+  lb_vip_addr:
+    value: { get_attr: [ loadbalancer, vip_address ] }
+
+  lb_vip_port_id:
+    value: { get_attr: [ loadbalancer, vip_port_id ] }
+
+  pool_id:
+    value: { get_attr: [ loadbalancer, pool ] }


### PR DESCRIPTION
Add LBaaS V1 as a new resource type

Create appropriate tests for the creation of a loadbalancer as
well as a loadbalanced cluster based on LBaaS V1

Differentiate between v1 and v2 for the sake of completeness,
but LBaaS V2 is still used by default