### PR TITLE
remove property: security_groups from OS::Nova::Server as demanded by Documentation

### DIFF
--- a/src/instance/basic.yaml
+++ b/src/instance/basic.yaml
@@ -122,7 +122,6 @@ resources:
       key_name: { get_param: key }
       networks:
         - port: { get_resource: port }
-      security_groups: { get_param: security_groups }
       user_data_format: SOFTWARE_CONFIG
       user_data: {get_resource: server_init}
       scheduler_hints: { get_param: scheduler_hints }


### PR DESCRIPTION
fixes #12 